### PR TITLE
Update getTeamIdPreference to use 'in' operator due to xml2js new ver…

### DIFF
--- a/hooks/lib/configXmlParser.js
+++ b/hooks/lib/configXmlParser.js
@@ -51,7 +51,7 @@ function readPreferences(cordovaContext) {
 // region Private API
 
 function getTeamIdPreference(xmlPreferences) {
-  if (xmlPreferences.hasOwnProperty('ios-team-id')) {
+  if ('ios-team-id' in xmlPreferences) {
     return xmlPreferences['ios-team-id'][0]['$']['value'];
   }
 


### PR DESCRIPTION
You cannot use hasOwnProperty in getTeamIdPreference (configXmlParser.js) due to the latest changes in xml2js:
https://github.com/Leonidas-from-XIV/node-xml2js/commit/581b19a62d88f8a3c068b5a45f4542c2d6a495a5#diff-2f45270c7389933f71b380538ff52e106ee5cb66a0b573d9967467dfdbc11c02R144